### PR TITLE
Add ECEF/EPSG 4978 projection functions

### DIFF
--- a/trilateration.js
+++ b/trilateration.js
@@ -140,4 +140,24 @@ function trilaterate(p1, p2, p3, return_middle)
 	}
 }
 
-module.exports = trilaterate;
+function toLonLat_epsgG4978(point) 
+{
+	let earthRadius = 6371;
+  	point.lon = Math.atan2(point.y, point.x) * (180 / Math.PI);
+  	point.lat = Math.asin(point.z / earthRadius / 1000) * (180 / Math.PI);
+
+  	return point;
+}
+
+function fromLonLat_epsg4978(point) 
+{
+  	let earthRadius = 6371;
+
+	point.x =earthRadius * 1000 * (Math.cos(point.lat * (Math.PI / 180)) * Math.cos(point.lon * (Math.PI / 180)));
+	point.y = earthRadius * 1000 * (Math.cos(point.lat * (Math.PI / 180)) * Math.sin(point.lon * (Math.PI / 180))); 
+	point.z = earthRadius * 1000 * Math.sin(point.lat * (Math.PI / 180));
+
+  	return point;
+}
+
+module.exports = { trilaterate, toLonLat_epsgG4978, fromLonLat_epsg4978 };


### PR DESCRIPTION
As the trilateration function does not work with ECEF/EPSG 4978 coordinates (used by Google Maps and OpenStreetMap), I'm adding the projection methods. 

These are also used in the python code of following stackexchange answer: https://gis.stackexchange.com/a/415, which looks very similiar as the trilateration function.
Other projections like proj4s did not gave correct results.